### PR TITLE
Customizing documentation on organization variables

### DIFF
--- a/_api/enterprise_get.md
+++ b/_api/enterprise_get.md
@@ -25,12 +25,12 @@ content_markdown: |-
 
 left_code_blocks:
   - code_block: |-
-     https://api.digitalhumani.com/enterprise/:id
+      !API_URL!/enterprise/:id
     title:
     language: bash
 right_request_blocks:
   - code_block: |1-
-     https://api.digitalhumani.com/enterprise/11111111
+     !API_URL!/enterprise/11111111
     title: Example request
     language: bash
 right_code_blocks:

--- a/_api/project_get.md
+++ b/_api/project_get.md
@@ -41,36 +41,36 @@ content_markdown: |-
 
 left_code_blocks:
   - code_block: |-
-      https://api.digitalhumani.com/project/:id
+      !API_URL!/project/:id
     title:
     language: bash
 right_request_blocks:
   - code_block: |1-
-     https://api.digitalhumani.com/project/96666666
+     !API_URL!/project/96666666
     title: Example request
     language: bash
 right_code_blocks:
   - code_block: |2-
       {
-        "reforestationCompanyName_fr": "WeForest",
-        "reforestationProjectImageURL_en": "https://www.weforest.org/sites/IMG_20190423_132725_0.jpg",
-        "reforestationCompanyName_en": "WeForest",
+        "reforestationCompanyName_fr": "OneTreePlanted",
+        "reforestationProjectImageURL_en": "https://cdn.shopify.com/s/files/1/0326/7189/products/india_aa36f63b-f455-4f5e-a6d3-2c0cc2d9936e_5000x.jpg?v=1636667460",
+        "reforestationCompanyName_en": "OneTreePlanted",
         "reforestationProjectCountry_en": "India",
         "reforestationCompanyAddress_en": "Ogentroostlaan 15, 3090 Overijse, Belgium",
         "created": "2018-12-12T09:05:00.725Z",
-        "reforestationProjectWebsite_en": "https://www.weforest.org/project/india-khasi-hills",
-        "name": "Khasi Hills in India, WeForest",
-        "reforestationProjectWebsite_fr": "https://www.weforest.org/project/india-khasi-hills",
+        "reforestationProjectWebsite_en": "https://onetreeplanted.org/collections/asia/products/india",
+        "name": "Khasi Hills in India",
+        "reforestationProjectWebsite_fr": "https://onetreeplanted.org/collections/asia/products/india",
         "reforestationProjectCountry_fr": "Inde",
         "updated": "2019-05-19T19:24:10.761Z",
         "reforestationProjectDescription_fr": "Projet de reforestation aux Khasi Hills en Inde",
         "reforestationProjectDescription_en": "Reforestation project in the Khasi Hills in India",
-        "reforestationCompanyWebsite_fr": "https://www.weforest.org/",
-        "reforestationCompanyWebsite_en": "https://www.weforest.org/",
+        "reforestationCompanyWebsite_fr": "https://onetreeplanted.org/",
+        "reforestationCompanyWebsite_en": "https://onetreeplanted.org/",
         "reforestationCompanyAddress_fr": "Ogentroostlaan 15, 3090 Overijse, Belgique",
-        "description": "Khasi Hills in India, WeForest",
+        "description": "Khasi Hills in India",
         "id": "96666666",
-        "reforestationProjectImageURL_fr": "https://www.weforest.org/sites/default/IMG_20190423_132725_0.jpg"
+        "reforestationProjectImageURL_fr": "https://cdn.shopify.com/s/files/1/0326/7189/products/india_aa36f63b-f455-4f5e-a6d3-2c0cc2d9936e_5000x.jpg?v=1636667460"
       }
     title: Example Response
     language: json

--- a/_api/projects_list.md
+++ b/_api/projects_list.md
@@ -26,12 +26,12 @@ content_markdown: |-
 
 left_code_blocks:
   - code_block: |-
-      https://api.digitalhumani.com/project
+      !API_URL!/project
     title:
     language: bash
 right_request_blocks:
   - code_block: |1-
-     https://api.digitalhumani.com/project
+     !API_URL!/project
     title: Example request
     language: bash
 right_code_blocks:
@@ -49,12 +49,12 @@ right_code_blocks:
         },
         {
           "id": "96666666",
-          "name": "Khasi Hills in India, WeForest",
+          "name": "Khasi Hills in India",
           "reforestationProjectDescription_en": "Reforestation project in the Khasi Hills in India",
           "reforestationProjectState_en": "Khasi Hills",
           "reforestationProjectCountry_en": "India",
-          "reforestationProjectWebsite_en": "https://www.weforest.org/project/india-khasi-hills",
-          "reforestationCompanyName_en": "WeForest",
+          "reforestationProjectWebsite_en": "https://onetreeplanted.org/collections/asia/products/india",
+          "reforestationCompanyName_en": "OneTreePlanted",
         }
       ]
     title: Example response (with 2 reforestation projects included)

--- a/_api/tree_get_enterprise_count.md
+++ b/_api/tree_get_enterprise_count.md
@@ -29,12 +29,12 @@ content_markdown: |-
 
 left_code_blocks:
   - code_block: |-
-     https://api.digitalhumani.com/enterprise/:id/treeCount?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
+     !API_URL!/enterprise/:id/treeCount?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD
     title:
     language: bash
 right_request_blocks:
   - code_block: |1-
-     https://api.digitalhumani.com/enterprise/11111111/treeCount?startDate=2010-03-01&endDate=2030-01-01
+     !API_URL!/enterprise/11111111/treeCount?startDate=2010-03-01&endDate=2030-01-01
     title: Example request
     language: bash
 right_code_blocks:

--- a/_api/tree_get_enterprise_month.md
+++ b/_api/tree_get_enterprise_month.md
@@ -24,12 +24,12 @@ content_markdown: |-
   **count** Number of trees planted by the enterprise for a specific month
 left_code_blocks:
   - code_block: |-
-     https://api.digitalhumani.com/enterprise/:id/treeCount/YYYY-MM
+     !API_URL!/enterprise/:id/treeCount/YYYY-MM
     title:
     language: bash
 right_request_blocks:
   - code_block: |1-
-     https://api.digitalhumani.com/enterprise/11111111/treeCount/2020-02
+     !API_URL!/enterprise/11111111/treeCount/2020-02
     title: Example request
     language: bash
 right_code_blocks:

--- a/_api/tree_get_request.md
+++ b/_api/tree_get_request.md
@@ -25,12 +25,12 @@ content_markdown: |-
   **user** End user by whom the trees were planted (string)
 left_code_blocks:
   - code_block: |-
-     https://api.digitalhumani.com/tree/:uuid-of-tree-planted
+     !API_URL!/tree/:uuid-of-tree-planted
     title:
     language: bash
 right_request_blocks:
   - code_block: |1-
-     https://api.digitalhumani.com/tree/bcd35c97-d66c-412e-89ae-ecbac0f629ac
+     !API_URL!/tree/bcd35c97-d66c-412e-89ae-ecbac0f629ac
     title: Example request
     language: bash
 right_code_blocks:

--- a/_api/tree_get_user.md
+++ b/_api/tree_get_user.md
@@ -26,12 +26,12 @@ content_markdown: |-
   **count** Number of trees planted by a specific user
 left_code_blocks:
   - code_block: |-
-     https://api.digitalhumani.com/tree?enterpriseId=:enterpriseId&user=:user
+     !API_URL!/tree?enterpriseId=:enterpriseId&user=:user
     title:
     language: bash
 right_request_blocks:
   - code_block: |1-
-     https://api.digitalhumani.com/tree?enterpriseId=48a45261&user=test_user_1
+     !API_URL!/tree?enterpriseId=48a45261&user=test_user_1
     title: Example request
     language: bash
 right_code_blocks:

--- a/_api/tree_plant.md
+++ b/_api/tree_plant.md
@@ -44,12 +44,12 @@ content_markdown: |-
 
 left_code_blocks:
   - code_block: |-
-     https://api.digitalhumani.com/tree + Body Parameters described below
+     !API_URL!/tree + Body Parameters described below
     title:
     language: bash
 right_request_blocks:
   - code_block: |1-
-     https://api.digitalhumani.com/tree
+     !API_URL!/tree
      Body parameters
      {
        "treeCount": 1,

--- a/_appendix/list-of-projects.md
+++ b/_appendix/list-of-projects.md
@@ -4,6 +4,7 @@ position_number: 1
 parameters:
   - name:
     content:
+published: {{ site.is_DH }}
 content_markdown: |-
   Here is the complete list of available projects from our 6 reforestation partners. They are all available in all environments.
 
@@ -58,5 +59,5 @@ content_markdown: |-
   | TIST | Kenya | 81818183 | program.tist.org/kenya |
   | To be determined | Where they are needed most | 14442771 ||
 
-  Back to the main page of the RaaS (Reforestation as a Service) main page at [DigitalHumani.com](https://digitalhumani.com)
+  Back to the main page of the RaaS (Reforestation as a Service) main page at [!ORG_NAME!](!SITE_URL!)
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,19 @@ google_analytics_key:
 permalink: pretty
 baseurl:
 
+org_name: Digital Humani
+is_DH: false
+base_url: https://docs.digitalhumani.com # This site
+site_url: https://digitalhumani.com # Marketing site
+api_url: https://api.digitalhumani.com
+dashboard_url: https://my.digitalhumani.com
+dashboard_register_url: https://my.digitalhumani.com/register
+logo_url: https://assets.dev.digitalhumani.com/org/logo.png
+sandbox_api: https://api.sandbox.digitalhumani.com/
+sandbox_dashboard: https://my.sandbox.digitalhumani.com/
+support_email: info@digitalhumani.com
+intro_header: Welcome to the documentation for the [Digital Humani](https://digitalhumani.com/) API! We refer to this service as **RaaS**, or "Reforestation as as Service". It is a simple API for planting trees with trusted reforestation organizations.
+
 # -----
 # Build
 
@@ -32,26 +45,21 @@ exclude:
   - readme.md
   - LICENSE
   - vendor
-  
 
 defaults:
-  -
-    scope:
+  - scope:
       path: ""
     values:
       layout: default
-  -
-    scope:
+  - scope:
       type: "documentation"
     values:
       _hide_content: true
-  -
-    scope:
+  - scope:
       type: "api"
     values:
       _hide_content: true
-  -
-    scope:
+  - scope:
       type: "appendix"
     values:
       _hide_content: true

--- a/_documentation/accessing-api.md
+++ b/_documentation/accessing-api.md
@@ -4,17 +4,17 @@ position_number: 2
 parameters:
   - name:
     content:
+published: false
 content_markdown: |-
   The API has two available endpoints:
-  
+
   **Production**
   <br/>
-  [https://api.digitalhumani.com/](https://api.digitalhumani.com/)
+  [!API_URL!](!API_URL!)
 
   **Sandbox**
   <br/>
-  [https://api.sandbox.digitalhumani.com/](https://api.sandbox.digitalhumani.com/)
+  [!SANDBOX_URL!](!SANDBOX_URL!)
 
   Each endpoint offers access to different environments. More information on the [Sandbox environment](/#documentationsandbox) available below.
-
 ---

--- a/_documentation/billing.md
+++ b/_documentation/billing.md
@@ -15,7 +15,7 @@ content_markdown: |-
 
   Note: Some reforestation organizations request a minimum number of tree planting requests before providing an invoice, normally around 20 trees. If you do not end up planting 20 trees within a month, we normally just extend the billing period until you do hit the minimum. 
   
-  This is a flexible process, and we're happy to help you through it - [reach out to us](mailto:info@digitalhumani.com) with any questions you have.
+  This is a flexible process, and we're happy to help you through it - [reach out to us](mailto:!SUPPORT_EMAIL!) with any questions you have.
 
   
 ---

--- a/_documentation/choose-project.md
+++ b/_documentation/choose-project.md
@@ -5,12 +5,12 @@ parameters:
   - name:
     content:
 content_markdown: |-
-  One of the most important first steps of planting trees is deciding where to plant them! We can help you with that process. DigitalHumani supports many great reforestation organizations around the world, so you can plant trees virtually anywhere. 
+  One of the most important first steps of planting trees is deciding where to plant them! We can help you with that process. !ORG_NAME! supports many great reforestation organizations around the world, so you can plant trees virtually anywhere. 
   
   A full list of projects you can support is available via the API - see the [`GET /project`](/#apiprojects_list)  request below.
 
   Not sure where to start? We have a few suggestions:
-  - Shoot us [an email](mailto:info@digitalhumani.com). We're happy to discuss your options in more detail.
+  - Shoot us [an email](mailto:info@!SUPPORT_EMAIL!). We're happy to discuss your options in more detail.
   - We've created a special project that plants trees *where they're needed most*. This will either defer the decision on where the trees are planted, or can be a temporary placeholder that can be updated to a different project later on. The ID for this project is *14442771*.
   
 ---

--- a/_documentation/getting-started.md
+++ b/_documentation/getting-started.md
@@ -5,7 +5,7 @@ parameters:
   - name:
     content:
 content_markdown: |-
-  You can get started using the API by registering on the DigitalHumani dashboard at [https://my.digitalhumani.com/register](https://my.digitalhumani.com/register).
+  You can get started using the API by registering on the !ORG_NAME! dashboard at [!DASHBOARD_REGISTER_URL!](!DASHBOARD_REGISTER_URL!).
 
   Once signed up, navigate to the *Developer* page to find your API key. You'll need that key to authenticate with the API. From that page, you'll also find your *enterpriseId* which will be useful in your API requests. 
 

--- a/_documentation/introduction.md
+++ b/_documentation/introduction.md
@@ -5,13 +5,13 @@ parameters:
   - name:
     content:
 content_markdown: |-
-  Welcome to the documentation for the [DigitalHumani](https://digitalhumani.com) API! We refer to this service as **RaaS**, or "Reforestation as as Service". It is a simple API for planting trees with trusted reforestation organizations.
+  !INTRO_HEADER!
 
   This is a *REST* API. All requests should be made over SSL, and all response bodies, including errors, are encoded in *JSON*. We likewise recommend that all requests be JSON encoded and include the `Content-Type: “application/json”` request header.
 
   This documentation will include some high-level information on topics such as authentication and billing followed by detailed information on available API routes. 
 
-  Got any questions, or looking something that's not specified in the docs? Feel free to shoot us a question at [info@digitalhumani.com](mailto:info@digitalhumani.com). We're here to help!
+  Got any questions, or looking something that's not specified in the docs? Feel free to shoot us a question at [!SUPPORT_EMAIL!](mailto:!SUPPORT_EMAIL!). We're here to help!
 
 left_code_blocks:
   - code_block:

--- a/_documentation/sandbox.md
+++ b/_documentation/sandbox.md
@@ -4,12 +4,13 @@ position_number: 4
 parameters:
   - name:
     content:
+published: {{ site.is_DH }}
 content_markdown: |-
   After registration, you will have access to 2 separate environments: Sandbox and Production.
 
   The Sandbox environment is used primarily for testing and getting familiar with the API. There are no costs associated with planting trees in Sandbox. Once you are ready to plant real trees, you should do so in the Production environment. 
 
-  You can access the Sandbox dashboard by logging in at [https://my.sandbox.digitalhumani.com](https://my.sandbox.digitalhumani.com). Initially, you will have the same login credentials for both Production and Sandbox.
+  You can access the Sandbox dashboard by logging in at [!SANDBOX_DASHBOARD!](!SANDBOX_DASHBOARD!). Initially, you will have the same login credentials for both Production and Sandbox.
 
   Note that you will have a separate API key in the Sandbox and Production environments. To access your API key, navigate to the *Developer* page.
   

--- a/_documentation/sdks-plugins.md
+++ b/_documentation/sdks-plugins.md
@@ -4,6 +4,7 @@ position_number: 7
 parameters:
   - name:
     content:
+published: {{ site.is_DH }}
 content_markdown: |-
   There are a number of integrations and SDKs available that you can use to easily integrate with the DigitalHumani API. 
 

--- a/_includes/syntax-highlight.html
+++ b/_includes/syntax-highlight.html
@@ -1,6 +1,6 @@
 {% capture highlight %}
 ``` {{ include.block.language }}
-{{ include.block.code_block | replace "!API_URL!", site.api_url }}
+{{ include.block.code_block | replace: "!API_URL!", site.api_url }}
 ```
 {: title="{{ include.block.title }}" }
 {% endcapture %}

--- a/_includes/syntax-highlight.html
+++ b/_includes/syntax-highlight.html
@@ -1,6 +1,6 @@
 {% capture highlight %}
 ``` {{ include.block.language }}
-{{ include.block.code_block }}
+{{ include.block.code_block | replace "!API_URL!", site.api_url }}
 ```
 {: title="{{ include.block.title }}" }
 {% endcapture %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,20 +23,11 @@
 	</head>
 	<body>
 		<header>
-			<h1 style="border-bottom: none; box-shadow: none;">
-				<button type="button" class="open-nav" id="open-nav"></button>
-				<!-- Force to digitalhumani docs' endpoint
-					<a href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/images/dh-logo.png" height="40" alt="{{ site.title }} logo"></a>-->
-				<a href="https://docs.digitalhumani.com"><img src="./images/dh-logo.png" style="height: 48px; margin-top: 15px;" alt="{{ site.title }} logo"></a>
-			</h1>
+			<a href="{{ site.base_url }}" class="site-logo">
+				<img src="{{ site.logo_url }}" alt="{{ site.org_name }} logo">
+			</a>
 
 			{% include sidebar.html %}
-
-			<p class="copyright">
-				<a href="https://cloudcannon.com/">
-					Template by CloudCannon
-				</a>
-			</p>
 		</header>
 		<div class="main">
 			{{ content }}

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -178,6 +178,17 @@ dl dd:after {
 	height: 0;
 }
 
+a.site-logo {
+	display: flex;
+    justify-content: center;
+    margin: 20px 0px 15px;
+}
+
+a.site-logo img {
+	aspect-ratio: 1;
+    width: 33%;
+}
+
 .sidebar h6 {
 	line-height: 1em;
 	font-size: 1.5rem;
@@ -187,7 +198,7 @@ dl dd:after {
 }
 
 .sidebar {
-	padding: 10px 0px 0 10px;
+	padding-left: 20px;
 	white-space:nowrap;
 	background-color: whitesmoke;
 	overflow-y: auto;
@@ -460,7 +471,7 @@ hr {
 }
 
 header {
-	max-height: 100vh;
+	height: 100vh;
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -515,7 +526,6 @@ header {
 	}
 
 	@media (min-width: $mobile-break) {
-		background-color: transparent;
 		width: $nav-width;
 		right: auto;
 		bottom: auto;

--- a/index.html
+++ b/index.html
@@ -42,7 +42,21 @@ title: API Docs
 							{% endfor %}
 						</table>
 				{% endif %}
-				{{ doc.content_markdown | markdownify | replace: "<dl>", "<h6>Parameters</h6><dl>" }}
+				{{ doc.content_markdown |
+					replace: "<dl>", "<h6>Parameters</h6><dl>" |
+					replace: "!ORG_NAME!", site.org_name |
+					replace: "!BASE_URL!", site.base_url |
+					replace: "!SITE_URL!", site.site_url |
+					replace: "!API_URL!", site.api_url |
+					replace: "!DASHBOARD_URL!", site.dashboard_url |
+					replace: "!DASHBOARD_REGISTER_URL!", site.dashboard_register_url |
+					replace: "!LOGO_URL!", site.logo_url |
+					replace: "!SANDBOX_API!", site.sandbox_api |
+					replace: "!SANDBOX_DASHBOARD!", site.sandbox_dashboard |
+					replace: "!SUPPORT_EMAIL!", site.support_email |
+					replace: "!INTRO_HEADER!", site.intro_header |
+					markdownify
+				}}
 
 			</section>
 			{% if doc.right_code_blocks and doc.right_code_blocks[0].code_block %}


### PR DESCRIPTION
Adds support for creating documentation site for other organizations via variables defined in `_config.yml`. 

@Xavbm Thanks for helping me get this far. Running into one more issues that I'm hoping you can help me with:

- I am attempting to dynamically render a document/file by setting a boolean configuration variable to the `published` (based on the [Jekyll docs](https://jekyllrb.com/docs/front-matter/)). However, I am not able to tell if A) the configuration variable is even being rendered correctly in this Front Matter and B) if the string is correctly parsed as a boolean to set `published` as needed. Here's an example. Any thoughts?